### PR TITLE
Feature/try methods (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-## [0.4.0]
+## [0.4.1]
+
+### Added
+
+- New methods (`I18nConfig::with_auto_locales`) to determine supported locales from deep search for translation files.
+
+- New methods returning `Result<_, Error>` rather than `panic!`, such that:
+
+  | __`panic!` version__                    | __`Result<_, Error>` vesion__            |
+  |--------------------------------  -------|------  ----------------------------------|
+  | `LocaleResource::to_resource_string`    | `LocaleResource::try_to_resource_string` |
+  | `I18n::translate`                       | `I18n::try_translate`                    |
+  | `I18n::translate_with_args`             | `I18n::try_translate_with_args`          |
+  | `I18n::set_fallback_language`           | `I18n::try_set_fallback_language`        |
+  | `I18n::set_language`                    | `I18n::try_set_language`                 |
+  | `use_init_i18n`                         | `try_use_init_i18n`                      |
+  | `I18nConfig::with_auto_locales`         | `I18nConfig::try_with_auto_locales`      |
+
+- New `te!` macro which acts like `t!` but returns `Error`.
+
+- New `tid!` macro which acts like `t!` but returns the message-id.
+
+### Change
+
+- t! macro amended to use `try_translate` and `try_translate_with_args`, but will perform `.expect("..")`
+  and therefore panic! on error. This retains backwards compatibility for this macro.
+
+- Use of `set_fallback_language` / `try_set_fallback_language` without a corresponding locale
+  translation is treated as an error.
+
+## [0.4.0] 2025-01-25
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dioxus-i18n"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Marc Espín <mespinsanz@gmail.com>"]
 description = "i18n integration for Dioxus apps based on Fluent Project."
@@ -16,7 +16,11 @@ dioxus-lib = { version = "0.6", default-features = false, features = [
     "signals",
 ] }
 fluent = "0.16.1"
+thiserror = "2.0.9"
 unic-langid = { version = "0.9.5", features = ["macros"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+walkdir = "2.5.0"
 
 [dev-dependencies]
 dioxus = { version = "0.6", features = ["desktop"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
+pub enum Error {
+    #[error("message id not found for key: '{0}'")]
+    MessageIdNotFound(String),
+
+    #[error("message pattern not found for key: '{0}'")]
+    MessagePatternNotFound(String),
+
+    #[error("fluent errors during lookup:\n{0}")]
+    FluentErrorsDetected(String),
+
+    #[error("failed to read locale resource from path: {0}")]
+    LocaleResourcePathReadFailed(String),
+
+    #[error("fallback for \"{0}\" must have locale")]
+    FallbackMustHaveLocale(String),
+
+    #[error("language id cannot be determined - reason: {0}")]
+    InvalidLanguageId(String),
+
+    #[error("invalid path: {0}")]
+    InvalidPath(String),
+}

--- a/src/i18n_macro.rs
+++ b/src/i18n_macro.rs
@@ -1,10 +1,51 @@
-/// Translate from key to formatted string, using `I18n::translate` or `I18n::translate_with_args`.
+//! Key translation macros.
+//!
+//! Using file:
+//!
+//! ```ftl
+//! # en-US.ftl
+//! #
+//! hello = Hello, {$name}!
+//! ```
+
+/// Translate message from key, returning [`crate::prelude::DioxusI18nError`] if id not found...
 ///
-/// ```ftl
-/// # en-US.ftl
-/// #
-/// hello = Hello, {$name}!
+/// ```rust
+/// # use dioxus::prelude::*;
+/// # use dioxus_i18n::{te, prelude::*};
+/// # use unic_langid::langid;
+/// # #[component]
+/// # fn Example() -> Element {
+/// #   let lang = langid!("en-US");
+/// #   let config = I18nConfig::new(lang.clone()).with_locale((lang.clone(), "hello = Hello, {$name}")).with_fallback(lang.clone());
+/// #   let mut i18n = use_init_i18n(|| config);
+/// let name = "Avery Gigglesworth";
+/// let hi = te!("hello", name: {name}).expect("message id 'name' should be present");
+/// assert_eq!(hi, "Hello, Avery Gigglesworth");
+/// #   rsx! { "" }
+/// # }
 /// ```
+///
+#[macro_export]
+macro_rules! te {
+    ($id:expr, $( $name:ident : $value:expr ),* ) => {
+        {
+            let mut params_map = dioxus_i18n::fluent::FluentArgs::new();
+            $(
+                params_map.set(stringify!($name), $value);
+            )*
+            dioxus_i18n::prelude::i18n().try_translate_with_args($id, Some(&params_map))
+        }
+    };
+
+    ($id:expr ) => {
+        {
+            dioxus_i18n::prelude::i18n().try_translate($id)
+        }
+    };
+}
+
+/// Translate message from key, panic! if id not found...
 ///
 /// ```rust
 /// # use dioxus::prelude::*;
@@ -25,18 +66,38 @@
 #[macro_export]
 macro_rules! t {
     ($id:expr, $( $name:ident : $value:expr ),* ) => {
-        {
-            let mut params_map = dioxus_i18n::fluent::FluentArgs::new();
-            $(
-                params_map.set(stringify!($name), $value);
-            )*
-            dioxus_i18n::prelude::i18n().translate_with_args($id, Some(&params_map))
-        }
+        dioxus_i18n::te!($id, $( $name : $value ),*).expect(concat!("message-id: ", $id, " should be translated"))
     };
 
-    ($id:expr ) => {
-        {
-            dioxus_i18n::prelude::i18n().translate($id)
-        }
+    ($id:expr ) => {{
+        dioxus_i18n::te!($id).expect(concat!("message-id: ", $id, " should be translated"))
+    }};
+}
+
+/// Translate message from key, return id if no translation found...
+///
+/// ```rust
+/// # use dioxus::prelude::*;
+/// # use dioxus_i18n::{tid, prelude::*};
+/// # use unic_langid::langid;
+/// # #[component]
+/// # fn Example() -> Element {
+/// #   let lang = langid!("en-US");
+/// #   let config = I18nConfig::new(lang.clone()).with_locale((lang.clone(), "hello = Hello, {$name}")).with_fallback(lang.clone());
+/// #   let mut i18n = use_init_i18n(|| config);
+/// let message = tid!("no-key");
+/// assert_eq!(message, "message-id: no-key should be translated");
+/// #   rsx! { "" }
+/// # }
+/// ```
+///
+#[macro_export]
+macro_rules! tid {
+    ($id:expr, $( $name:ident : $value:expr ),* ) => {
+        dioxus_i18n::te!($id, $( $name : $value ),*).unwrap_or(format!("message-id: {:?} should be translated", $id))
     };
+
+    ($id:expr ) => {{
+        dioxus_i18n::te!($id).unwrap_or(format!("message-id: {:?} should be translated", $id))
+    }};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,5 @@
-//! # dioxus-i18n 🌍
-//!
-//! i18n integration for Dioxus apps based on the [Project Fluent](https://github.com/projectfluent/fluent-rs).
-//!
-//! ## Example:
-//!
-//! ```ftl
-//! # en-US.ftl
-//! #
-//! hello = Hello, {$name}!
-//! ```
-//!
-//! ```rust
-//! # use dioxus::prelude::*;
-//! # use dioxus_i18n::{t, prelude::*};
-//! # use unic_langid::langid;
-//! # use std::path::PathBuf;
-//! #
-//! fn app() -> Element {
-//!     let i18 = use_init_i18n(|| {
-//!         I18nConfig::new(langid!("en-US"))
-//!             .with_locale(( // Embed
-//!                 langid!("en-US"),
-//!                 include_str!("../examples/en-US.ftl"),
-//!             ))
-//!             .with_locale(( // Load at launch
-//!                 langid!("es-ES"),
-//!                 PathBuf::from("../examples/es-ES.ftl"),
-//!             ))
-//!     });
-//!
-//!     rsx!(
-//!         label { { t!("hello", name: "World") } }
-//!     )
-//! }
-//! ```
-//!
+#![doc = include_str!("../README.md")]
+mod error;
 pub mod i18n_macro;
 pub mod use_i18n;
 
@@ -42,5 +7,6 @@ pub use fluent;
 pub use unic_langid;
 
 pub mod prelude {
+    pub use crate::error::Error as DioxusI18nError;
     pub use crate::use_i18n::*;
 }

--- a/tests/graceful_fallback_spec.rs
+++ b/tests/graceful_fallback_spec.rs
@@ -4,14 +4,14 @@ use common::*;
 use dioxus_i18n::prelude::{use_init_i18n, I18n, I18nConfig};
 use unic_langid::{langid, LanguageIdentifier};
 
-use std::cell::LazyCell;
-
 #[test]
 fn exact_locale_match_will_use_translation() {
     test_hook(i18n, |value, proxy| {
         proxy.assert(
-            &value.translate("variants"),
-            "variants only",
+            value
+                .try_translate("variants")
+                .expect("test message id must exist"),
+            "variants only".to_string(),
             "exact_locale_match_will_use_translation",
         );
     });
@@ -21,8 +21,10 @@ fn exact_locale_match_will_use_translation() {
 fn non_exact_locale_match_will_use_region() {
     test_hook(i18n, |value, proxy| {
         proxy.assert(
-            &value.translate("region"),
-            "region only",
+            value
+                .try_translate("region")
+                .expect("test message id must exist"),
+            "region only".to_string(),
             "non_exact_locale_match_will_use_region",
         );
     });
@@ -32,8 +34,10 @@ fn non_exact_locale_match_will_use_region() {
 fn non_exact_locale_match_will_use_script() {
     test_hook(i18n, |value, proxy| {
         proxy.assert(
-            &value.translate("script"),
-            "script only",
+            value
+                .try_translate("script")
+                .expect("test message id must exist"),
+            "script only".to_string(),
             "non_exact_locale_match_will_use_script",
         );
     });
@@ -43,8 +47,10 @@ fn non_exact_locale_match_will_use_script() {
 fn non_exact_locale_match_will_use_language() {
     test_hook(i18n, |value, proxy| {
         proxy.assert(
-            &value.translate("language"),
-            "language only",
+            value
+                .try_translate("language")
+                .expect("test message id must exist"),
+            "language only".to_string(),
             "non_exact_locale_match_will_use_language",
         );
     });
@@ -54,22 +60,23 @@ fn non_exact_locale_match_will_use_language() {
 fn no_locale_match_will_use_fallback() {
     test_hook(i18n, |value, proxy| {
         proxy.assert(
-            &value.translate("fallback"),
-            "fallback only",
+            value
+                .try_translate("fallback")
+                .expect("test message id must exist"),
+            "fallback only".to_string(),
             "no_locale_match_will_use_fallback",
         );
     });
 }
 
-const FALLBACK_LANG: LanguageIdentifier = langid!("fb-FB");
-const LANGUAGE_LANG: LanguageIdentifier = langid!("la");
-const SCRIPT_LANG: LanguageIdentifier = langid!("la-Scpt");
-const REGION_LANG: LanguageIdentifier = langid!("la-Scpt-LA");
-const VARIANTS_LANG: LazyCell<LanguageIdentifier> =
-    LazyCell::new(|| langid!("la-Scpt-LA-variants"));
-
 fn i18n() -> I18n {
-    let config = I18nConfig::new(VARIANTS_LANG.clone())
+    const FALLBACK_LANG: LanguageIdentifier = langid!("fb-FB");
+    const LANGUAGE_LANG: LanguageIdentifier = langid!("la");
+    const SCRIPT_LANG: LanguageIdentifier = langid!("la-Scpt");
+    const REGION_LANG: LanguageIdentifier = langid!("la-Scpt-LA");
+    let variants_lang: LanguageIdentifier = langid!("la-Scpt-LA-variants");
+
+    let config = I18nConfig::new(variants_lang.clone())
         .with_locale((LANGUAGE_LANG, include_str!("../tests/data/fallback/la.ftl")))
         .with_locale((
             SCRIPT_LANG,
@@ -80,7 +87,7 @@ fn i18n() -> I18n {
             include_str!("../tests/data/fallback/la-Scpt-LA.ftl"),
         ))
         .with_locale((
-            VARIANTS_LANG.clone(),
+            variants_lang.clone(),
             include_str!("../tests/data/fallback/la-Scpt-LA-variants.ftl"),
         ))
         .with_locale((

--- a/tests/translations_spec.rs
+++ b/tests/translations_spec.rs
@@ -3,7 +3,7 @@ use common::*;
 
 use dioxus_i18n::{
     prelude::{use_init_i18n, I18n, I18nConfig},
-    t,
+    t, te, tid,
 };
 use unic_langid::{langid, LanguageIdentifier};
 
@@ -12,10 +12,14 @@ use std::path::PathBuf;
 #[test]
 fn translate_from_static_source() {
     test_hook(i18n_from_static, |_, proxy| {
-        let name = "World";
+        let panic = std::panic::catch_unwind(|| {
+            let name = "World";
+            t!("hello", name: name)
+        });
+        proxy.assert(panic.is_ok(), true, "translate_from_static_source");
         proxy.assert(
-            &t!("hello", name: name),
-            "Hello, \u{2068}World\u{2069}!",
+            panic.ok().unwrap(),
+            "Hello, \u{2068}World\u{2069}!".to_string(),
             "translate_from_static_source",
         );
     });
@@ -27,10 +31,74 @@ fn failed_to_translate_with_invalid_key() {
         let panic = std::panic::catch_unwind(|| {
             let _ = &t!("invalid");
         });
+        proxy.assert(panic.is_err(), true, "failed_to_translate_with_invalid_key");
+    });
+}
+
+#[test]
+fn failed_to_translate_with_invalid_key_as_error() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| te!("invalid"));
         proxy.assert(
-            &panic.is_err().to_string(),
-            "true",
-            "failed_to_translate_with_invalid_key",
+            panic.is_ok(),
+            true,
+            "failed_to_translate_with_invalid_key_as_error",
+        );
+        proxy.assert(
+            panic.ok().unwrap().err().unwrap().to_string(),
+            "message id not found for key: 'invalid'".to_string(),
+            "failed_to_translate_with_invalid_key_as_error",
+        );
+    });
+}
+
+#[test]
+fn failed_to_translate_with_invalid_key_with_args_as_error() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| te!("invalid", name: "<don't care>"));
+        proxy.assert(
+            panic.is_ok(),
+            true,
+            "failed_to_translate_with_invalid_key_with_args_as_error",
+        );
+        proxy.assert(
+            panic.ok().unwrap().err().unwrap().to_string(),
+            "message id not found for key: 'invalid'".to_string(),
+            "failed_to_translate_with_invalid_key_with_args_as_error",
+        );
+    });
+}
+
+#[test]
+fn failed_to_translate_with_invalid_key_as_id() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| tid!("invalid"));
+        proxy.assert(
+            panic.is_ok(),
+            true,
+            "failed_to_translate_with_invalid_key_as_id",
+        );
+        proxy.assert(
+            panic.ok().unwrap(),
+            "message-id: \"invalid\" should be translated".to_string(),
+            "failed_to_translate_with_invalid_key_as_id",
+        );
+    });
+}
+
+#[test]
+fn failed_to_translate_with_invalid_key_with_args_as_id() {
+    test_hook(i18n_from_static, |_, proxy| {
+        let panic = std::panic::catch_unwind(|| tid!("invalid", name: "<don't care>"));
+        proxy.assert(
+            panic.is_ok(),
+            true,
+            "failed_to_translate_with_invalid_key_with_args_as_id",
+        );
+        proxy.assert(
+            panic.ok().unwrap(),
+            "message-id: \"invalid\" should be translated".to_string(),
+            "failed_to_translate_with_invalid_key_with_args_as_id",
         );
     });
 }
@@ -38,35 +106,40 @@ fn failed_to_translate_with_invalid_key() {
 #[test]
 fn translate_from_dynamic_source() {
     test_hook(i18n_from_dynamic, |_, proxy| {
-        let name = "World";
+        let panic = std::panic::catch_unwind(|| {
+            let name = "World";
+            t!("hello", name: name)
+        });
+        proxy.assert(panic.is_ok(), true, "translate_from_dynamic_source");
         proxy.assert(
-            &t!("hello", name: name),
-            "Hello, \u{2068}World\u{2069}!",
+            panic.ok().unwrap(),
+            "Hello, \u{2068}World\u{2069}!".to_string(),
             "translate_from_dynamic_source",
         );
     });
 }
 
 #[test]
+#[should_panic]
+#[ignore] // Panic hidden within test_hook.
+fn fail_translate_from_dynamic_source_when_file_does_not_exist() {
+    test_hook(i18n_from_dynamic_none_existing, |_, _| unreachable!());
+}
+
+#[test]
 fn initial_language_is_set() {
     test_hook(i18n_from_static, |value, proxy| {
-        proxy.assert(
-            &value.language().to_string(),
-            &EN.to_string(),
-            "initial_language_is_set",
-        );
+        proxy.assert(value.language(), EN, "initial_language_is_set");
     });
 }
 
 #[test]
 fn language_can_be_set() {
     test_hook(i18n_from_static, |mut value, proxy| {
-        value.set_language(JP);
-        proxy.assert(
-            &value.language().to_string(),
-            &JP.to_string(),
-            "language_can_be_set",
-        );
+        value
+            .try_set_language(JP)
+            .expect("set_language must succeed");
+        proxy.assert(value.language(), JP, "language_can_be_set");
     });
 }
 
@@ -74,8 +147,8 @@ fn language_can_be_set() {
 fn no_default_fallback_language() {
     test_hook(i18n_from_static, |value, proxy| {
         proxy.assert(
-            &format!("{:?}", value.fallback_language()),
-            "None",
+            format!("{:?}", value.fallback_language()),
+            "None".to_string(),
             "no_default_fallback_language",
         );
     });
@@ -85,8 +158,8 @@ fn no_default_fallback_language() {
 fn some_default_fallback_language() {
     test_hook(i18n_from_static_with_fallback, |value, proxy| {
         proxy.assert(
-            &format!("{:?}", value.fallback_language().map(|l| l.to_string())),
-            "Some(\"jp\")",
+            format!("{:?}", value.fallback_language().map(|l| l.to_string())),
+            "Some(\"jp\")".to_string(),
             "some_default_fallback_language",
         );
     });
@@ -95,17 +168,42 @@ fn some_default_fallback_language() {
 #[test]
 fn fallback_language_can_be_set() {
     test_hook(i18n_from_static_with_fallback, |mut value, proxy| {
-        value.set_fallback_language(DE);
+        value
+            .try_set_fallback_language(EN)
+            .expect("try_set_fallback_language must succeed");
         proxy.assert(
-            &format!("{:?}", value.fallback_language().map(|l| l.to_string())),
-            "Some(\"de\")",
+            format!("{:?}", value.fallback_language().map(|l| l.to_string())),
+            "Some(\"en\")".to_string(),
             "fallback_language_can_be_set",
         );
     });
 }
 
-const DE: LanguageIdentifier = langid!("de");
+#[test]
+fn fallback_language_must_have_locale_translation() {
+    test_hook(i18n_from_static_with_fallback, |mut value, proxy| {
+        let result = value.try_set_fallback_language(IT);
+
+        proxy.assert(
+            result.is_err(),
+            true,
+            "fallback_language_must_have_locale_translation",
+        );
+        proxy.assert(
+            result.err().unwrap().to_string(),
+            "fallback for \"it\" must have locale".to_string(),
+            "fallback_language_must_have_locale_translation",
+        );
+        proxy.assert(
+            format!("{:?}", value.fallback_language().map(|l| l.to_string())),
+            "Some(\"jp\")".to_string(),
+            "fallback_language_must_have_locale_translation",
+        );
+    });
+}
+
 const EN: LanguageIdentifier = langid!("en");
+const IT: LanguageIdentifier = langid!("it");
 const JP: LanguageIdentifier = langid!("jp");
 
 fn i18n_from_static() -> I18n {
@@ -125,6 +223,17 @@ fn i18n_from_dynamic() -> I18n {
         EN,
         PathBuf::from(format!(
             "{}/tests/data/i18n/en.ftl",
+            env!("CARGO_MANIFEST_DIR")
+        )),
+    ));
+    use_init_i18n(|| config)
+}
+
+fn i18n_from_dynamic_none_existing() -> I18n {
+    let config = I18nConfig::new(EN).with_locale((
+        EN,
+        PathBuf::from(format!(
+            "{}/tests/data/i18n/non_existing.ftl",
             env!("CARGO_MANIFEST_DIR")
         )),
     ));


### PR DESCRIPTION
* README.md typo

* Add tests and new with_locale interface

* Add documentation

* Graceful fallback; use cached active_bundle during translation

* Move graceful_fallback_tests to integration testing

* Test 'deprecated' constructors

* Integration tests for static & dynamic derivation

* Add 'trivial' test cases

* Add changelog

* Clippified

* Add test for message-id not found

* Added history to CHANGELOG

* Refactor the .with_locale(Into<Locale>) code

* Enable shared LocaleResources

* Add try_ constructs around any panicable methods

* Update documentation

* Add I18nConfig::with_auto_locales

* Improved error messages

* Remove deprecation warnings

* Update src/use_i18n.rs

Reword LocaleResource comment



* Update src/use_i18n.rs

Update comment for set_language



* Remove debris

* README example comment updates

* Clippy; example; and 'use .peek()' changes from 2nd review

* .gitignore Cargo.lock

* Update date in CHANGELOG for v0.4.0

* Update src/i18n_macro.rs

Remove comment re backward compatibility for t! macro; not needed



* Update src/use_i18n.rs

Shadow result in with_auto_locales



* PR Review changes

* Remove cargo.lock

* Ignore cargo.lock in future

* Ignore cargo.lock in future 2

---------