### PR TITLE
Changelog typos (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.2]
+## [0.4.2] 2025-02-08
 
 ### Fixed
 
@@ -20,7 +20,7 @@
 
 - New methods returning `Result<_, Error>` rather than `panic!`, such that:
   | __`panic!` version__                    | __`Result<_, Error>` vesion__            |
-  |--------------------------------  -------|------  ----------------------------------|
+  |-----------------------------------------|------------------------------------------|
   | `LocaleResource::to_resource_string`    | `LocaleResource::try_to_resource_string` |
   | `I18n::translate`                       | `I18n::try_translate`                    |
   | `I18n::translate_with_args`             | `I18n::try_translate_with_args`          |


### PR DESCRIPTION
* fix: issue #15: Recent change to t! macro unnecessarily breaks v0.3 code

* Bump version to 0.4.2

* Change macro t! expect to unwrap_or_else; align error messaging in macros

* Amend changelog

* Table formatting in changelog

* Update CHANGELOG; table layout

* Update CHANGELOG; table layout 2

* Update CHANGELOG; table layout 3